### PR TITLE
Fix: language button persist 미들웨어 적용

### DIFF
--- a/src/store/countStore.ts
+++ b/src/store/countStore.ts
@@ -8,9 +8,7 @@ type CountState = {
 };
 
 type CountActions = {
-  // actions: {
-  // };
-  openAlert: () => void;
+  openAlert: (message?: string) => void;
   increaseCount: () => void;
   resetCount: () => void;
   getStorage: () => void;
@@ -20,7 +18,7 @@ const countStorageKey = 'count-store';
 
 const initialCount = {
   count: 0,
-  storage: '',
+  storage: null,
 };
 
 const useCountStoreBase = create<CountState & CountActions>()(
@@ -28,11 +26,11 @@ const useCountStoreBase = create<CountState & CountActions>()(
     persist(
       immer(set => ({
         ...initialCount,
-        openAlert: () => {
-          alert('test');
+        openAlert: (message = '테스트 입니다.') => {
+          alert(message);
         },
         increaseCount: () =>
-          set((state: { count: number }) => {
+          set(state => {
             state.count += 1;
           }),
         resetCount: () => set(initialCount),

--- a/src/store/languageStore.ts
+++ b/src/store/languageStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
 
 type LanguageState = {
   language: string;
@@ -8,13 +9,23 @@ type LanguageAction = {
   changeLng: (lang: string) => void;
 };
 
+const languageStoreKey = 'language-store';
+
 const initialLanguage = {
   language: 'en',
 };
 
-const useLanguageStore = create<LanguageState & LanguageAction>(set => ({
-  ...initialLanguage,
-  changeLng: lang => set({ language: lang }),
-}));
+const useLanguageStore = create<LanguageState & LanguageAction>()(
+  persist(
+    set => ({
+      ...initialLanguage,
+      changeLng: lang => set({ language: lang }),
+    }),
+    {
+      name: languageStoreKey,
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);
 
 export default useLanguageStore;


### PR DESCRIPTION
언어 설정 변경 시 해당 브라우저에서 지속적으로 유지를 위해 언어타입 전역변수 persist 미들웨어 적용. 로컬스토리지에 저장.

#code_review